### PR TITLE
Fix invalid workflow files: remove empty `with:` blocks after checkout steps

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -103,7 +103,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Cache vcpkg
         uses: actions/cache@v4
@@ -222,7 +221,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Cache vcpkg
         uses: actions/cache@v4
@@ -334,7 +332,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Cache vcpkg
         uses: actions/cache@v4
@@ -414,7 +411,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Install dependencies
         run: |
@@ -464,7 +460,6 @@ jobs:
     needs: linux-build
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Download Linux build artifacts
         uses: actions/download-artifact@v4
@@ -515,7 +510,6 @@ jobs:
     needs: [linux-build, integration-tests]
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Install dependencies
         run: |
@@ -583,7 +577,6 @@ jobs:
     needs: linux-build
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Install dependencies
         run: |
@@ -147,7 +146,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Install packaging dependencies
         run: |
@@ -279,7 +277,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Setup MSVC
         uses: ilammy/msvc-dev-cmd@v1
@@ -437,7 +434,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Fixes #19 — the `e2e-ci.yml` workflow failed GitHub Actions validation:

> Invalid workflow file: .github/workflows/e2e-ci.yml#L1
> (Line: 106, Col: 14): Unexpected value '', (Line: 225, Col: 14): Unexpected value '', (Line: 337, Col: 14): Unexpected value '', (Line: 417, Col: 14): Unexpected value '', (Line: 467, Col: 14): Unexpected value '', (Line: 518, Col: 14): Unexpected value '', (Line: 586, Col: 14): Unexpected value ''

## Root cause

Each flagged line was an empty `with:` mapping dangling under an `actions/checkout@v4` step:

```yaml
- uses: actions/checkout@v4
  with:

- name: Cache vcpkg
```

GitHub Actions rejects a `with:` key with no inputs. `release.yml` contained the same broken pattern in 4 more places (lines 75, 150, 282, 440).

## Fix

Removed all 11 dangling `with:` lines (7 in `e2e-ci.yml`, 4 in `release.yml`). The checkout steps need no inputs — the repository has no `.gitmodules`, and other workflows in the repo use bare `actions/checkout@v4` the same way.

## Verification

- Both files parse cleanly with a YAML loader
- All 10 jobs present in each workflow (`preflight`, `code-quality`, `linux-build`, `windows-build`, `macos-build`, `sanitizer-tests`, `integration-tests`, `e2e-tests`, `coverage`, `ci-summary` / release equivalents)
- No remaining empty `with:` blocks in any workflow file

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> YAML-only CI config fix with no change to build logic or checkout inputs.
> 
> **Overview**
> Fixes **GitHub Actions workflow validation** failures caused by empty `with:` mappings on `actions/checkout@v4` steps.
> 
> Removes **11 dangling `with:` lines**—seven in `e2e-ci.yml` (linux/windows/macos build, sanitizers, integration, e2e, coverage) and four in `release.yml` (linux-release, linux-packages, windows-release, macos-release). Checkout steps are now bare `uses: actions/checkout@v4`, consistent with other workflows in the repo that do not need checkout inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71242a18f2482d44bfe2572c1b8384295201d853. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->